### PR TITLE
All clobbers endpoints

### DIFF
--- a/relengapi/blueprints/clobberer/__init__.py
+++ b/relengapi/blueprints/clobberer/__init__.py
@@ -144,16 +144,6 @@ def lastclobber_all():
     return session.query(ClobberTime).order_by(ClobberTime.lastclobber)
 
 
-@bp.route('/lastclobber/greater-than/<int:mintime>', methods=['GET'])
-@apimethod([rest.ClobberTime], int)
-def lastclobber_greater_than(mintime):
-    "Return a sorted list of all clobbers greater than the time passed in"
-    session = g.db.session(DB_DECLARATIVE_BASE)
-    return session.query(ClobberTime).filter(
-        ClobberTime.lastclobber > mintime
-    ).order_by(ClobberTime.lastclobber)
-
-
 @bp.route('/lastclobber/branch/by-builder/<string:branch>', methods=['GET'])
 @apimethod({unicode: [rest.ClobberTime]}, unicode)
 def lastclobber_by_builder(branch):

--- a/relengapi/blueprints/clobberer/__init__.py
+++ b/relengapi/blueprints/clobberer/__init__.py
@@ -148,9 +148,6 @@ def lastclobber_all():
 @apimethod({unicode: [rest.ClobberTime]}, unicode)
 def lastclobber_by_builder(branch):
     "Return a dictionary of most recent ClobberTimes grouped by buildername."
-    # TODO: simplify this query, new clobberer _only_ tracks max clobber times
-    #  - old clobberer did not - so this query may be simplified under that
-    # assuption
     session = g.db.session(DB_DECLARATIVE_BASE)
 
     # Isolates the maximum lastclobber for each builddir on a branch

--- a/relengapi/blueprints/clobberer/__init__.py
+++ b/relengapi/blueprints/clobberer/__init__.py
@@ -158,7 +158,9 @@ def lastclobber_greater_than(mintime):
 @apimethod({unicode: [rest.ClobberTime]}, unicode)
 def lastclobber_by_builder(branch):
     "Return a dictionary of most recent ClobberTimes grouped by buildername."
-
+    # TODO: simplify this query, new clobberer _only_ tracks max clobber times
+    #  - old clobberer did not - so this query may be simplified under that
+    # assuption
     session = g.db.session(DB_DECLARATIVE_BASE)
 
     # Isolates the maximum lastclobber for each builddir on a branch

--- a/relengapi/blueprints/clobberer/__init__.py
+++ b/relengapi/blueprints/clobberer/__init__.py
@@ -136,6 +136,24 @@ def branches():
     return [branch[0] for branch in branches]
 
 
+@bp.route('/lastclobber/all', methods=['GET'])
+@apimethod([rest.ClobberTime])
+def lastclobber_all():
+    "Return a sorted list of all clobbers"
+    session = g.db.session(DB_DECLARATIVE_BASE)
+    return session.query(ClobberTime).order_by(ClobberTime.lastclobber)
+
+
+@bp.route('/lastclobber/greater-than/<int:mintime>', methods=['GET'])
+@apimethod([rest.ClobberTime], int)
+def lastclobber_greater_than(mintime):
+    "Return a sorted list of all clobbers greater than the time passed in"
+    session = g.db.session(DB_DECLARATIVE_BASE)
+    return session.query(ClobberTime).filter(
+        ClobberTime.lastclobber > mintime
+    ).order_by(ClobberTime.lastclobber)
+
+
 @bp.route('/lastclobber/branch/by-builder/<string:branch>', methods=['GET'])
 @apimethod({unicode: [rest.ClobberTime]}, unicode)
 def lastclobber_by_builder(branch):

--- a/relengapi/blueprints/clobberer/test_api.py
+++ b/relengapi/blueprints/clobberer/test_api.py
@@ -58,27 +58,6 @@ def test_lastclobber_all(client):
     eq_(len(clobbertimes), len(_clobber_args))
 
 
-@ test_context
-def test_lastclobber_greater_than(client):
-    session = test_context._app.db.session(DB_DECLARATIVE_BASE)
-    min_ct = session.query(ClobberTime.lastclobber).order_by(
-        ClobberTime.lastclobber
-    ).first()[0]
-
-    # since this is less than the min, we should see all the results
-    lt_min_ct = min_ct - 1
-    rv = client.get('/clobberer/lastclobber/greater-than/%i' % lt_min_ct)
-    eq_(rv.status_code, 200)
-    lt_min_ct_result = json.loads(rv.data)["result"]
-    eq_(len(lt_min_ct_result), len(_clobber_args))
-
-    # now we should see less than last time
-    rv = client.get('/clobberer/lastclobber/greater-than/%i' % min_ct)
-    eq_(rv.status_code, 200)
-    min_ct_result = json.loads(rv.data)["result"]
-    assert len(lt_min_ct_result) > len(min_ct_result)
-
-
 @test_context
 def test_clobber_request_of_release(client):
     "Ensures that attempting to clobber a release build will fail."


### PR DESCRIPTION
Two new endpoints, which allow one to get an overall view of what has been recently clobbered. Using these endpoints in tandem, you could build a manifest (with all) then update it periodically (using greater-than) to achieve branch agnostic bulk clobbers.

/clobberer/lastclobber/all
/clobberer/lastclobber/greater-than/<timestamp>