### PR TITLE
Bug 1164878 - Allow users without an authenticated_email field to clo…

### DIFF
--- a/relengapi/blueprints/clobberer/__init__.py
+++ b/relengapi/blueprints/clobberer/__init__.py
@@ -68,9 +68,16 @@ def _add_clobber(session, branch, builddir, slave=None):
     in is returned; but is only committed if the commit option is True.
     """
     if re.search('^' + BUILDDIR_REL_PREFIX + '.*', builddir) is None:
-        who = 'anonymous'
-        if current_user.anonymous is False:
+        try:
             who = current_user.authenticated_email
+        except AttributeError:
+            if current_user.anonymous:
+                who = 'anonymous'
+            else:
+                # TokenUser doesn't show up as anonymous; but also has no
+                # authenticated_email
+                who = 'automation'
+
         clobber_time = ClobberTime.as_unique(
             session,
             branch=branch,

--- a/relengapi/blueprints/clobberer/test_api.py
+++ b/relengapi/blueprints/clobberer/test_api.py
@@ -293,3 +293,15 @@ def test_release_builder_hiding(client):
     eq_(rv.status_code, 200)
     clobbertimes = json.loads(rv.data)["result"]
     eq_(clobbertimes.get(buildername), None)
+
+
+@test_context
+def test_clobber_request_no_identity(client):
+    del auth_user.authenticated_email
+    session = test_context._app.db.session(DB_DECLARATIVE_BASE)
+    rv = client.post_json('/clobberer/clobber', data=[_clobber_args, _clobber_args_with_slave])
+    eq_(rv.status_code, 200)
+    clobber = session.query(ClobberTime.who)
+    # the last clobber should have a who value of automation, since we deleted
+    # authenticated_email
+    eq_(clobber.order_by('id').all()[0], ('automation',))


### PR DESCRIPTION
…bber

The TokenUser is not anonymous, but also has no e-mail address associated with it.
When this combination occurs, a who value of 'automation' should be supplied, instead
of outright failing.

While not exact, the term automation gives us a way to categorize clobbers that seemed
to be authenticated by a permanent token (as opposed to a user token).